### PR TITLE
Map Hotfix

### DIFF
--- a/LaCulture_UI/src/app/components/home/home.component.html
+++ b/LaCulture_UI/src/app/components/home/home.component.html
@@ -20,7 +20,7 @@
 </div>
 
 
-<app-map>*ngIf="selectedOption === 'Map'" </app-map>
+<app-map *ngIf="selectedOption === 'Map'"></app-map>
 
 <!-- TODO: add quicklinks -->
 <div class="white-section"></div>


### PR DESCRIPTION
Simple 1-line fix, fixing the map always appearing under the carousel (even when not on map page)